### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a Model Context Protocol (MCP) server that provides access to all endpoints of the [MonkeyType API](https://api.monkeytype.com/docs/). The server exposes MCP tools that allow Large Language Models (LLMs) to interact with the MonkeyType API.
 
+<a href="https://glama.ai/mcp/servers/@CodeDreamer06/MonkeytypeMCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CodeDreamer06/MonkeytypeMCP/badge" alt="MonkeyType Server MCP server" />
+</a>
+
 ## Features
 
 - Exposes all MonkeyType API endpoints as MCP tools


### PR DESCRIPTION
This PR adds a badge for the [MonkeyType MCP Server](https://glama.ai/mcp/servers/@CodeDreamer06/MonkeytypeMCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@CodeDreamer06/MonkeytypeMCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@CodeDreamer06/MonkeytypeMCP/badge" alt="MonkeyType Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.